### PR TITLE
make sure /api/github does nothing with public projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+test:
+	node_modules/.bin/bailey ./ ./ --node
+	ABAKUS_TOKEN=test HOOK_TOKEN=test node_modules/.bin/istanbul cover node_modules/.bin/_mocha
+
+.PHONY: test

--- a/package.json
+++ b/package.json
@@ -35,10 +35,16 @@
     "request": "^2.40.0"
   },
   "devDependencies": {
+    "chai": "^1.9.1",
+    "chai-spies": "^0.5.1",
     "gulp": "^3.8.7",
     "gulp-bailey": "^0.2.0",
     "gulp-ignore": "^1.2.0",
     "gulp-stylus": "^1.3.0",
-    "gulp-util": "^3.0.0"
+    "gulp-util": "^3.0.0",
+    "istanbul": "^0.3.2",
+    "mocha": "^1.21.4",
+    "should": "^4.0.4",
+    "supertest": "^0.13.0"
   }
 }

--- a/routes/api.bs
+++ b/routes/api.bs
@@ -21,7 +21,10 @@ router.post('/deploy/:projectName', (req, res, next) ->
     deployAndHandle(req.params.projectName, req.query.debug, res)
 )
 
-notMasterMessage = 'Received hook from a different branch than master, nothing will be done.'
+messages = {
+    notMaster: 'Received hook from a different branch than master, nothing will be done.'
+    handledByTravis: 'Received hook from a public project, which is handled by Travis. Nothing will be done.'
+}
 
 router.post('/github', (req, res) ->
     payload = req.body
@@ -33,13 +36,15 @@ router.post('/github', (req, res) ->
 
     correct = 'sha1=' + hmac.read()
 
-    if payload.ref == 'refs/heads/master'
-        if signature == correct
-            deployAndHandle(payload.repository.name, true, res)
+    if signature == correct
+        if payload.ref != 'refs/heads/master'
+            res.status(200).send(messages.notMaster)
+        elif payload.repository and not payload.repository.private
+            res.status(200).send(messages.handledByTravis)
         else
-            res.status(403).send()
+            deployAndHandle(payload.repository.name, true, res)
     else
-        res.status(200).send(notMasterMessage)
+        res.status(403).send()
 
 )
 

--- a/test/api.bs
+++ b/test/api.bs
@@ -1,0 +1,52 @@
+import should
+import chai
+import chai-spies as spies
+import assert
+import supertest as request
+
+import ../app
+import ../routes/api: messages
+import ../deploy
+import ./fixtures/github-push as ghPushFixture
+
+expect = chai.expect
+chai.use(spies)
+
+describe('API', () ->
+  describe('/github', () ->
+    HASH = 'sha1=7876c938d38e99b954b3d839c7bafb343d29e776'
+    HASH_WITH_PAYLOAD = 'sha1=afc5f9b9343a32bdb7c3c5357a9b5aeebe69ebd8'
+    deploySpy = undefined
+    beforeEach(() ->
+      deploySpy = chai.spy(deploy)
+    )
+      
+
+    it('should return 403 when auth fails', (done) ->
+      request(app)
+        .post('/api/github')
+        .expect(403, done)
+    )
+
+    it('should return 200 when auth succeeds', (done) ->
+      request(app)
+        .post('/api/github')
+        .set('x-hub-signature', HASH)
+        .expect(200, done)
+    )
+
+    it('should not deploy if project is public', (done) ->
+      request(app)
+        .post('/api/github')
+        .set('x-hub-signature', HASH_WITH_PAYLOAD)
+        .send(ghPushFixture)
+        .expect(200)
+        .end((err, res) ->
+          expect(err).to.be.null
+          expect(res.text).to.equal('Received hook from a public project, which is handled by Travis. Nothing will be done.')
+          expect(deploySpy).not.to.have.been.called
+          done()
+        )
+    )
+  )
+)

--- a/test/fixtures/github-push.bs
+++ b/test/fixtures/github-push.bs
@@ -1,0 +1,141 @@
+export {
+  "ref": "refs/heads/master",
+  "after": "1edd67c078c1767031452ddc2dfd3c5f46d96081",
+  "before": "3ed49707cc13efedb71c46445da94159688a4621",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "compare": "https://github.com/webkom/coffee/compare/3ed49707cc13...1edd67c078c1",
+  "commits": [
+    {
+      "id": "1edd67c078c1767031452ddc2dfd3c5f46d96081",
+      "distinct": true,
+      "message": "add make production",
+      "timestamp": "2014-09-12T12:05:12+02:00",
+      "url": "https://github.com/webkom/coffee/commit/1edd67c078c1767031452ddc2dfd3c5f46d96081",
+      "author": {
+        "name": "Rolf Erik Lekang",
+        "email": "me@rolflekang.com",
+        "username": "relekang"
+      },
+      "committer": {
+        "name": "Rolf Erik Lekang",
+        "email": "me@rolflekang.com",
+        "username": "relekang"
+      },
+      "added": [
+
+      ],
+      "removed": [
+
+      ],
+      "modified": [
+        "Makefile"
+      ]
+    }
+  ],
+  "head_commit": {
+    "id": "1edd67c078c1767031452ddc2dfd3c5f46d96081",
+    "distinct": true,
+    "message": "add make production",
+    "timestamp": "2014-09-12T12:05:12+02:00",
+    "url": "https://github.com/webkom/coffee/commit/1edd67c078c1767031452ddc2dfd3c5f46d96081",
+    "author": {
+      "name": "Rolf Erik Lekang",
+      "email": "me@rolflekang.com",
+      "username": "relekang"
+    },
+    "committer": {
+      "name": "Rolf Erik Lekang",
+      "email": "me@rolflekang.com",
+      "username": "relekang"
+    },
+    "added": [
+
+    ],
+    "removed": [
+
+    ],
+    "modified": [
+      "Makefile"
+    ]
+  },
+  "repository": {
+    "id": 14572118,
+    "name": "coffee",
+    "full_name": "webkom/coffee",
+    "owner": {
+      "name": "webkom",
+      "email": null
+    },
+    "private": false,
+    "html_url": "https://github.com/webkom/coffee",
+    "description": "An API to the Moccamaster at the Abakus office",
+    "fork": false,
+    "url": "https://github.com/webkom/coffee",
+    "forks_url": "https://api.github.com/repos/webkom/coffee/forks",
+    "keys_url": "https://api.github.com/repos/webkom/coffee/keys{/key_id}",
+    "collaborators_url": "https://api.github.com/repos/webkom/coffee/collaborators{/collaborator}",
+    "teams_url": "https://api.github.com/repos/webkom/coffee/teams",
+    "hooks_url": "https://api.github.com/repos/webkom/coffee/hooks",
+    "issue_events_url": "https://api.github.com/repos/webkom/coffee/issues/events{/number}",
+    "events_url": "https://api.github.com/repos/webkom/coffee/events",
+    "assignees_url": "https://api.github.com/repos/webkom/coffee/assignees{/user}",
+    "branches_url": "https://api.github.com/repos/webkom/coffee/branches{/branch}",
+    "tags_url": "https://api.github.com/repos/webkom/coffee/tags",
+    "blobs_url": "https://api.github.com/repos/webkom/coffee/git/blobs{/sha}",
+    "git_tags_url": "https://api.github.com/repos/webkom/coffee/git/tags{/sha}",
+    "git_refs_url": "https://api.github.com/repos/webkom/coffee/git/refs{/sha}",
+    "trees_url": "https://api.github.com/repos/webkom/coffee/git/trees{/sha}",
+    "statuses_url": "https://api.github.com/repos/webkom/coffee/statuses/{sha}",
+    "languages_url": "https://api.github.com/repos/webkom/coffee/languages",
+    "stargazers_url": "https://api.github.com/repos/webkom/coffee/stargazers",
+    "contributors_url": "https://api.github.com/repos/webkom/coffee/contributors",
+    "subscribers_url": "https://api.github.com/repos/webkom/coffee/subscribers",
+    "subscription_url": "https://api.github.com/repos/webkom/coffee/subscription",
+    "commits_url": "https://api.github.com/repos/webkom/coffee/commits{/sha}",
+    "git_commits_url": "https://api.github.com/repos/webkom/coffee/git/commits{/sha}",
+    "comments_url": "https://api.github.com/repos/webkom/coffee/comments{/number}",
+    "issue_comment_url": "https://api.github.com/repos/webkom/coffee/issues/comments/{number}",
+    "contents_url": "https://api.github.com/repos/webkom/coffee/contents/{+path}",
+    "compare_url": "https://api.github.com/repos/webkom/coffee/compare/{base}...{head}",
+    "merges_url": "https://api.github.com/repos/webkom/coffee/merges",
+    "archive_url": "https://api.github.com/repos/webkom/coffee/{archive_format}{/ref}",
+    "downloads_url": "https://api.github.com/repos/webkom/coffee/downloads",
+    "issues_url": "https://api.github.com/repos/webkom/coffee/issues{/number}",
+    "pulls_url": "https://api.github.com/repos/webkom/coffee/pulls{/number}",
+    "milestones_url": "https://api.github.com/repos/webkom/coffee/milestones{/number}",
+    "notifications_url": "https://api.github.com/repos/webkom/coffee/notifications{?since,all,participating}",
+    "labels_url": "https://api.github.com/repos/webkom/coffee/labels{/name}",
+    "releases_url": "https://api.github.com/repos/webkom/coffee/releases{/id}",
+    "created_at": 1384989509,
+    "updated_at": "2014-09-11T16:59:39Z",
+    "pushed_at": 1410516328,
+    "git_url": "git://github.com/webkom/coffee.git",
+    "ssh_url": "git@github.com:webkom/coffee.git",
+    "clone_url": "https://github.com/webkom/coffee.git",
+    "svn_url": "https://github.com/webkom/coffee",
+    "homepage": "kaffe.abakus.no",
+    "size": 855,
+    "stargazers_count": 11,
+    "watchers_count": 11,
+    "language": "Python",
+    "has_issues": true,
+    "has_downloads": true,
+    "has_wiki": false,
+    "forks_count": 0,
+    "mirror_url": null,
+    "open_issues_count": 4,
+    "forks": 0,
+    "open_issues": 4,
+    "watchers": 11,
+    "default_branch": "master",
+    "stargazers": 11,
+    "master_branch": "master",
+    "organization": "webkom"
+  },
+  "pusher": {
+    "name": "relekang",
+    "email": "me@rolflekang.com"
+  }
+}


### PR DESCRIPTION
If a project is public we should run tests on travis and use that status
to deploy. However, we want chewie to know about the commits. That way
we are able to show status on the chewie index when we get that up and
running. This commit also adds a test to make sure deploy is not called.
