### PR TITLE
Add make production to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ifeq ($(findstring $(CORRECT),$(HOSTNAME)),$(CORRECT))
 	git fetch && git reset --hard origin/master
 	npm install
 	$(GULP)
-	forever restart index.js
+	forever restart $(PWD)/index.js
 else
 	@echo "Not in a production environment!"
 endif


### PR DESCRIPTION
`ifeq ($(findstring $(CORRECT),$(HOSTNAME)),$(CORRECT))` ensures that `hostname -f` contains abakus.no, so that it'll only run in production (so you don't run `git reset --hard origin/master` on accident).

Not sure if there's a better way to do it? @Hanse @relekang 
