### PR TITLE
Remove direct deploy API

### DIFF
--- a/routes/api.bs
+++ b/routes/api.bs
@@ -22,10 +22,6 @@ deployAndHandle = (projectName, debug, res) ->
     handleError(err, res)
   )
 
-router.post('/deploy/:projectName', authHelpers.isAuthenticated, (req, res, next) ->
-  deployAndHandle(req.params.projectName, req.query.debug, res)
-)
-
 messages = {
   notMaster: 'Received hook from a different branch than master, nothing will be done.'
   notStatusEvent: 'Not a status event, nothing will be done.'


### PR DESCRIPTION
This removes the direct API endpoint to deploy, as we don't use it anymore (the frontend uses websockets). The use case was originally if we wanted to integrate deployments through Slack etc., but it's kind of overkill now that we have both automatic deployments on status and a frontend where you can do it.

It's also quite lacking at the moment (see #37), so I suggest we remove it until we actually find a usecase for it. 
