### PR TITLE
Refactor deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install: node_modules
 run: venv parse
 	ABAKUS_TOKEN=test HOOK_TOKEN=test SERVER_CONFIG_FILE=$(PWD)/example.json $(CHEWIE)
 
-test: parse
+test: venv parse
 	ABAKUS_TOKEN=test HOOK_TOKEN=test SERVER_CONFIG_FILE=$(PWD)/example.json $(ISTANBUL) cover $(MOCHA) dist/test
 
 clean:

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cookie-parser": "^1.3.2",
     "cookie-session": "^1.0.2",
     "debug": "^1.0.4",
+    "eventemitter3": "^0.1.6",
     "express": "^4.8.5",
     "express-flash": "0.0.2",
     "gulp-nodemon": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "chai-spies": "^0.5.1",
     "istanbul": "^0.3.2",
     "mocha": "^1.21.4",
+    "mock-spawn": "^0.2.3",
     "should": "^4.0.4",
     "supertest": "^0.13.0"
   }

--- a/src/server/deploy.bs
+++ b/src/server/deploy.bs
@@ -29,12 +29,12 @@ class Deployment extends EventEmitter
     )
 
     proc.stderr.on('data', (data) ->
-      @@errors += data
+      @@stderr += data
       @@emit('stderr', data)
     )
 
     proc.on('close', (code) ->
-      @@emit('done', @@stderr.length == 0)
+      @@emit('done', code == 0)
       @@notify()
     )
 

--- a/src/server/deploy.bs
+++ b/src/server/deploy.bs
@@ -15,6 +15,7 @@ class Deployment extends EventEmitter
   init: (project, options) ->
     @stdout = ''
     @stderr = ''
+    @success = null
     @project = project
     @options = options or {}
 
@@ -34,12 +35,13 @@ class Deployment extends EventEmitter
     )
 
     proc.on('close', (code) ->
-      @@emit('done', code == 0)
+      @@success = code == 0
+      @@emit('done', @@success)
       @@notify()
     )
 
   notify: () ->
-    if @stderr.length == 0
+    if @success
       notifySuccess(@project, @options.source)
     else
       notifyError(@project, @options.source, @stderr)

--- a/src/server/deploy.bs
+++ b/src/server/deploy.bs
@@ -1,34 +1,45 @@
 import child_process as child
 import bluebird as Promise
+import eventemitter3 as EventEmitter
+import ./notify: notifySuccess, notifyError
 
-export {
-  deployRegular: deployRegular
-  deployStream: deployStream
-}
+export Deployment
 
 child_process = Promise.promisifyAll(child)
 
-python = '#{process.cwd()}/venv/bin/python'
-deployScript = '#{process.cwd()}/deploy.py'
 
-shortOutput = 'Done!'
+class Deployment extends EventEmitter
+  python: '#{process.cwd()}/venv/bin/python'
+  deployScript: '#{process.cwd()}/deploy.py'
 
-class DeployError extends Error
-  name: 'DeployError'
+  init: (project, options) ->
+    @stdout = ''
+    @stderr = ''
+    @project = project
+    @options = options or {}
 
-  init: (message) ->
-    @message = message
+  run: () ->
+    proc = child_process.spawn(@python, [@deployScript, @project])
+    proc.stdout.setEncoding('utf8')
+    proc.stderr.setEncoding('utf8')
 
+    proc.stdout.on('data', (data) ->
+      @@stdout += data
+      @@emit('stdout', data)
+    )
 
-deployStream = (projectName) ->
-  return child_process.spawn(python, [deployScript, projectName])
+    proc.stderr.on('data', (data) ->
+      @@errors += data
+      @@emit('stderr', data)
+    )
 
-deployRegular = (projectName, debug) ->
-  return child_process.execAsync('#{python} #{deployScript} #{projectName}')
-  .spread((stdout, stderr) ->
-    if stderr
-      throw new DeployError(stderr)
-    return debug ? stdout : shortOutput
-  , (err) ->
-    throw new DeployError(err.message)
-  )
+    proc.on('close', (code) ->
+      @@emit('done', @@stderr.length == 0)
+      @@notify()
+    )
+
+  notify: () ->
+    if @stderr.length == 0
+      notifySuccess(@project, @options.source)
+    else
+      notifyError(@project, @options.source, @stderr)

--- a/src/server/routes/api.bs
+++ b/src/server/routes/api.bs
@@ -2,36 +2,13 @@ import express
 import crypto
 
 import ../config
-import ../deploy
-import ../notify: notifySuccess, notifyError
+import ../deploy as Deployment
 import ./handle-error as handleError
 import ./auth-helpers as authHelpers: isAuthenticated
 
 export router
 
 router = express.Router()
-
-deployAndHandle = (projectName, debug, res) ->
-  deploy.deployRegular(projectName, debug)
-  .then((output) ->
-    res
-      .status(200)
-      .json({
-        status: 200
-        output: output
-      })
-    notifySuccess(projectName, 'webhook')
-  )
-  .catch((err) ->
-    notifyError(projectName, 'webhook', err)
-    handleError(err, res)
-  )
-
-messages = {
-  notMaster: 'Received hook from a different branch than master, nothing will be done.'
-  notStatusEvent: 'Not a status event, nothing will be done.'
-  notSuccess: 'State is not success, nothing will be done.'
-}
 
 router.post('/github', (req, res) ->
   payload = req.body
@@ -67,3 +44,22 @@ router.post('/github', (req, res) ->
         error: 'Invalid hook signature.'
       })
 )
+
+messages = {
+  notMaster: 'Received hook from a different branch than master, nothing will be done.'
+  notStatusEvent: 'Not a status event, nothing will be done.'
+  notSuccess: 'State is not success, nothing will be done.'
+}
+
+deployAndHandle = (project, debug, res) ->
+  deployment = new Deployment(project, { debug: debug source: 'webhook' })
+  deployment.on('done', (success) ->
+    if success
+      res.json({
+        status: 200
+        output: output
+      })
+    else
+      handleError(deployment.error, res)
+  )
+  deployment.run()

--- a/src/server/websockets/index.bs
+++ b/src/server/websockets/index.bs
@@ -1,32 +1,13 @@
-import ../deploy
-import ../notify: notifySuccess, notifyError
+import ../deploy as Deployment
 
 export handleMessages
 
-handleDeploy = (client, projectName) ->
-  stream = deploy.deployStream(projectName)
-
-  errors = ''
-
-  stream.stdout.setEncoding('utf8')
-  stream.stdout.on('data', (data) ->
-    client.emit('deploy_data', data)
-  )
-
-  stream.stderr.setEncoding('utf8')
-  stream.stderr.on('data', (data) ->
-    errors += data
-    client.emit('deploy_data', data)
-  )
-
-  stream.on('close', (code) ->
-    client.emit('deploy_done')
-
-    if errors.length
-      notifyError(projectName, 'frontend', errors)
-    else
-      notifySuccess(projectName, 'frontend')
-  )
+handleDeploy = (client, project) ->
+  deployment = new Deployment(project, { source: 'web-ui'})
+  deployment.on('stderr', (data) -> client.emit('deploy_data', data))
+  deployment.on('stdout', (data) -> client.emit('deploy_data', data))
+  deployment.on('done', (success) -> client.emit('deploy_done'))
+  deployment.run()
 
 handleMessages = (io) ->
   io.on('connection', (client) ->

--- a/test/api.bs
+++ b/test/api.bs
@@ -1,7 +1,5 @@
-import should
 import chai
 import chai-spies as spies
-import assert
 import supertest as request
 
 import ../app

--- a/test/deploy-test.bs
+++ b/test/deploy-test.bs
@@ -1,0 +1,72 @@
+import chai: expect
+import mock-spawn as mSpawn
+
+spawn = mSpawn()
+require('child_process').spawn = spawn
+Deployment = require('../deploy')
+
+spawn.setDefault(spawn.simple(0, 'deploying all the things'))
+
+describe('Deployment', () ->
+  deployment = null
+
+  describe('.init()', () ->
+
+    beforeEach(() ->
+      deployment = new Deployment('chewie', { source: 'tests' })
+    )
+
+    it('should set stdout to ""', () -> expect(deployment.stdout).to.equal(''))
+
+    it('should set stderr to ""', () -> expect(deployment.stderr).to.equal(''))
+
+    it('should set variables from arguments', () ->
+      expect(deployment.project).to.equal('chewie')
+      expect(deployment.options.source).to.equal('tests')
+    )
+  )
+  describe('.run()', () ->
+    beforeEach(() ->
+      deployment = new Deployment('src', { source: 'tests' })
+    )
+
+    it('should run the test', (done) ->
+      deployment.on('done', () -> done())
+      deployment.run()
+    )
+
+    it('should emit stdout', (done) ->
+      stdout = ''
+      deployment.on('stdout', (data) -> stdout += data)
+      deployment.on('done', () ->
+        expect(deployment.stdout).to.equal('deploying all the things')
+        expect(stdout).to.equal('deploying all the things')
+        done()
+      )
+      deployment.run()
+    )
+
+    it('should emit stderr', (done) ->
+      spawn.sequence.add(spawn.simple(1, '', 'All the errors'))
+      stderr = ''
+      deployment.on('stderr', (data) -> stderr += data)
+      deployment.on('done', (success) ->
+        expect(deployment.stderr).to.equal('All the errors')
+        expect(stderr).to.equal('All the errors')
+        expect(success).to.be.false
+        done()
+      )
+      deployment.run()
+    )
+
+    it('should report failure if the command failed', (done) ->
+      spawn.sequence.add(spawn.simple(1, '', ''))
+      deployment = new Deployment('chewie', { source: 'tests' })
+      deployment.on('done', (success) ->
+        expect(success).to.be.false
+        done()
+      )
+      deployment.run()
+    )
+  )
+)


### PR DESCRIPTION
Combine deployment script for websocket and api in order to make it
easier to hook in output parsers without duplicate code.