### PR TITLE
Fail fabric on prompt

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -10,6 +10,8 @@ import sys
 import json
 from fabric.api import env, run, cd
 
+env.abort_on_prompts = True
+
 
 class MissingProjectNameError(Exception):
     def __init__(self):


### PR DESCRIPTION
This will make fabric abort rather than prompt for passwords. This will
stop the deployment from freezing waiting for user input.