### PR TITLE
Only listen on localhost

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ debug = debug('chewie');
 
 app.set('port', process.env.PORT || 3000);
 
-server.listen(app.get('port'), function() {
+server.listen(app.get('port'), 'localhost', function() {
   debug('Listening on port ' + server.address().port);
 });
 


### PR DESCRIPTION
Apparently http.Server.listen has the opposite default of Express' listen.